### PR TITLE
added key transfer with node join

### DIFF
--- a/src/main/java/org/distributed/systems/chord/actors/MemcachedActor.java
+++ b/src/main/java/org/distributed/systems/chord/actors/MemcachedActor.java
@@ -20,7 +20,6 @@ import scala.concurrent.Future;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.concurrent.Callable;
 
 import static akka.dispatch.Futures.future;
 

--- a/src/main/java/org/distributed/systems/chord/actors/MemcachedActor.java
+++ b/src/main/java/org/distributed/systems/chord/actors/MemcachedActor.java
@@ -74,7 +74,7 @@ class MemcachedActor extends AbstractActor {
 
                         if (rply.value != null) {
                             int payload_length = rply.value.toString().length();
-                            ByteString getdataresp = ByteString.fromString(rply.value.toString() + "\r\n");
+                            ByteString getdataresp = ByteString.fromString(rply.value.getOriginalKey().toString() + "\r\n");
                             ByteString getresp = ByteString.fromString("VALUE " + key + " 0 " + (payload_length) + " \r\n");
                             client.tell(TcpMessage.write(getresp), getSelf());
                             client.tell(TcpMessage.write(getdataresp), getSelf());

--- a/src/main/java/org/distributed/systems/chord/actors/MemcachedActor.java
+++ b/src/main/java/org/distributed/systems/chord/actors/MemcachedActor.java
@@ -74,7 +74,7 @@ class MemcachedActor extends AbstractActor {
 
                         if (rply.value != null) {
                             int payload_length = rply.value.toString().length();
-                            ByteString getdataresp = ByteString.fromString(rply.value.getOriginalKey().toString() + "\r\n");
+                            ByteString getdataresp = ByteString.fromString(rply.value.getValue().toString() + "\r\n");
                             ByteString getresp = ByteString.fromString("VALUE " + key + " 0 " + (payload_length) + " \r\n");
                             client.tell(TcpMessage.write(getresp), getSelf());
                             client.tell(TcpMessage.write(getdataresp), getSelf());

--- a/src/main/java/org/distributed/systems/chord/actors/NodeActor.java
+++ b/src/main/java/org/distributed/systems/chord/actors/NodeActor.java
@@ -115,16 +115,18 @@ public class NodeActor extends AbstractActor {
         if (shouldKeyBeOnThisNodeOtherwiseForward(hashKey, new KeyValue.Put(hashKey, value))) {
             putValueInStore(hashKey, value);
             getSender().tell(new KeyValue.PutReply(hashKey, value), getSelf());
-    private void putValueForKey(long hashKey, String originalKey, Serializable value) {
-        putValueForKey(new KeyValue.Put(originalKey, hashKey, value));
-    }
-
-    private void putValueForKey(KeyValue.Put msg) {
-        if (shouldKeyBeOnThisNodeOtherwiseForward(msg.hashKey, msg)) {
-            putValueInStore(msg);
-            getSender().tell(new KeyValue.PutReply(msg.originalKey, msg.hashKey, msg.value), getSelf());
         }
     }
+//    private void putValueForKey(long hashKey, String originalKey, Serializable value) {
+//        putValueForKey(new KeyValue.Put(originalKey, hashKey, value));
+//    }
+
+//    private void putValueForKey(KeyValue.Put msg) {
+//        if (shouldKeyBeOnThisNodeOtherwiseForward(msg.hashKey, msg)) {
+//            putValueInStore(msg);
+//            getSender().tell(new KeyValue.PutReply(msg.originalKey, msg.hashKey, msg.value), getSelf());
+//        }
+//    }
 
     private void deleteKey(KeyValue.Delete msg) {
         if (shouldKeyBeOnThisNodeOtherwiseForward(msg.hashKey, msg)) {
@@ -143,9 +145,10 @@ public class NodeActor extends AbstractActor {
     //FIXME: Merge Conflict
     private void putValueInStore(long hashKey, Pair<String, Serializable> value) {
         storageActorRef.tell(new KeyValue.Put(hashKey, value), getSelf());
-    private void putValueInStore(long hashKey, String originalKey, Serializable value) {
-        putValueInStore(new KeyValue.Put(originalKey, hashKey, value));
     }
+//    private void putValueInStore(long hashKey, String originalKey, Serializable value) {
+//        putValueInStore(new KeyValue.Put(originalKey, hashKey, value));
+//    }
 
     private boolean shouldKeyBeOnThisNodeOtherwiseForward(long key, Command commandMessage) {
         if (nodeId == fingerTableService.getSuccessor().id) { // I'm the only node in the network
@@ -283,7 +286,7 @@ public class NodeActor extends AbstractActor {
                     putValueForKey(hashKey, value);
                     //FIXME: Merge Conflict
                     // We need to pass the original message, to ensure that memcache actor gets a reply
-                    putValueForKey(putValueMessage);
+//                    putValueForKey(putValueMessage);
                 })
                 .match(KeyValue.Delete.class, deleteMessage -> {
                     deleteKey(deleteMessage);

--- a/src/main/java/org/distributed/systems/chord/actors/NodeActor.java
+++ b/src/main/java/org/distributed/systems/chord/actors/NodeActor.java
@@ -151,7 +151,7 @@ public class NodeActor extends AbstractActor {
                     System.out.println("Successor: " + this.fingerTableService.getSuccessor());
                     fingerTableService.printFingerTable(true);
 
-                    // TODO: extract into new method
+                    // TODO: Only call this when predecessor is known, but where?
                     // calculate key range by looking at predecessor value
                     List<Long> keyRange = LongStream.range(this.fingerTableService.getPredecessor().id + 1, this.nodeId)
                             .boxed()

--- a/src/main/java/org/distributed/systems/chord/actors/NodeActor.java
+++ b/src/main/java/org/distributed/systems/chord/actors/NodeActor.java
@@ -220,7 +220,6 @@ public class NodeActor extends AbstractActor {
                     // TODO: Remove Dublicate Ifs (to conform to pseudocode)
                     if (fingerTableService.getPredecessor().chordRef == null) {
                         fingerTableService.setPredecessor(msg.nPrime);
-                        System.out.println("Transferring keys...");
                         transferKeysOnJoin();
                     } else if (CompareUtil.isBetweenExclusive(fingerTableService.getPredecessor().id, this.nodeId, msg.nPrime.id)) {
                         fingerTableService.setPredecessor(msg.nPrime);
@@ -385,6 +384,7 @@ public class NodeActor extends AbstractActor {
         // tell my storageActor to ask my successor for transfer keys.
         ActorRef successor = fingerTableService.getSuccessor().chordRef;
         if(getSelf() != successor){
+            System.out.println("Transferring keys...");
             this.storageActorRef.tell(new KeyTransfer.Request(successor, keyRange), getSelf());
         }
     }

--- a/src/main/java/org/distributed/systems/chord/actors/StorageActor.java
+++ b/src/main/java/org/distributed/systems/chord/actors/StorageActor.java
@@ -61,10 +61,16 @@ class StorageActor extends AbstractActor {
                     this.storageService.putAll(getSubsetReply.keyValues);
 
                     // todo call delete for keys (that contained a value)
+                    storageActorGetReply.storageActor.tell(new KeyValue.DeleteSubset(keyTransferMessage.keys), getSelf());
+
                 })
                 .match(KeyValue.GetSubset.class, getSubsetMessage ->{
                     // Get subset from Key value store based on list of keys
                     getSender().tell(new KeyValue.GetSubsetReply(this.storageService.getSubset(getSubsetMessage.keys)), getSelf());
+                })
+                .match(KeyValue.DeleteSubset.class, deleteSubsetMessage ->{
+                    // Delete subset from Key value store
+                    this.storageService.deleteSubset(deleteSubsetMessage.keys);
                 })
                 .match(KeyValue.Delete.class, deleteMessage -> {
                     this.storageService.delete(deleteMessage.hashKey);

--- a/src/main/java/org/distributed/systems/chord/actors/StorageActor.java
+++ b/src/main/java/org/distributed/systems/chord/actors/StorageActor.java
@@ -65,7 +65,7 @@ class StorageActor extends AbstractActor {
                     getSender().tell(new KeyValue.GetSubsetReply(this.storageService.getSubset(getSubsetMessage.keys)), getSelf());
                 })
                 .match(KeyValue.Delete.class, deleteMessage -> {
-                    this.storageService.delete(deleteMessage.originalKey);
+                    this.storageService.delete(deleteMessage.hashKey);
                     getContext().getSender().tell(new KeyValue.DeleteReply(), ActorRef.noSender());
                 })
                 .build();

--- a/src/main/java/org/distributed/systems/chord/actors/StorageActor.java
+++ b/src/main/java/org/distributed/systems/chord/actors/StorageActor.java
@@ -4,10 +4,19 @@ import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
+import akka.pattern.Patterns;
+import akka.util.Timeout;
+import org.distributed.systems.ChordStart;
+import org.distributed.systems.chord.messaging.GetActorRef;
+import org.distributed.systems.chord.messaging.KeyTransfer;
 import org.distributed.systems.chord.messaging.KeyValue;
+import org.distributed.systems.chord.models.Pair;
 import org.distributed.systems.chord.service.StorageService;
+import scala.concurrent.Await;
+import scala.concurrent.Future;
 
 import java.io.Serializable;
+import java.time.Duration;
 
 class StorageActor extends AbstractActor {
     private final LoggingAdapter log = Logging.getLogger(getContext().getSystem(), this);
@@ -23,21 +32,37 @@ class StorageActor extends AbstractActor {
         return receiveBuilder()
                 .match(KeyValue.Put.class, putValueMessage -> {
                     long hashKey = putValueMessage.hashKey;
-                    Serializable value = putValueMessage.value;
+                    Pair<String, Serializable> value = putValueMessage.value;
                     System.out.println("Put key " + hashKey);
-                    this.storageService.put(putValueMessage.originalKey, value);
+                    this.storageService.put(hashKey, value);
 
                     ActorRef optionalSender = getContext().getSender();
                     if (optionalSender != getContext().getSystem().deadLetters()) {
-                        optionalSender.tell(new KeyValue.PutReply(putValueMessage.originalKey, hashKey, value), ActorRef.noSender());
+                        optionalSender.tell(new KeyValue.PutReply(hashKey, value), ActorRef.noSender());
                     }
 
                 })
                 .match(KeyValue.Get.class, getValueMessage -> {
                     long key = getValueMessage.hashKey;
                     System.out.println("GET key " + key);
-                    Serializable val = this.storageService.get(getValueMessage.originalKey);
-                    getContext().getSender().tell(new KeyValue.GetReply(getValueMessage.originalKey, key, val), ActorRef.noSender());
+                    Pair<String, Serializable> val = this.storageService.get(key);
+                    getContext().getSender().tell(new KeyValue.GetReply(key, val), ActorRef.noSender());
+                })
+                .match(KeyTransfer.Request.class, keyTransferMessage ->{
+                    Timeout timeoutTransfer = Timeout.create(Duration.ofMillis(ChordStart.STANDARD_TIME_OUT));
+
+                    // first ask the storage actor ref of the successor
+
+                    Future<Object> storageActorGetFuture = Patterns.ask(keyTransferMessage.successor, new GetActorRef.Request(), timeoutTransfer);
+                    GetActorRef.Reply storageActorGetReply = (GetActorRef.Reply) Await.result(storageActorGetFuture, timeoutTransfer.duration());
+                    // next, ask the successor's storage actor for the keys
+                    Future<Object> getSubsetFuture = Patterns.ask(storageActorGetReply.storageActor, new KeyValue.GetSubset(keyTransferMessage.keys), timeoutTransfer);
+                    KeyValue.GetSubsetReply getSubsetReply = (KeyValue.GetSubsetReply) Await.result(getSubsetFuture, timeoutTransfer.duration());
+                    this.storageService.putAll(getSubsetReply.keyValues);
+                })
+                .match(KeyValue.GetSubset.class, getSubsetMessage ->{
+                    // Get subset from Key value store based on list of keys
+                    getSender().tell(new KeyValue.GetSubsetReply(this.storageService.getSubset(getSubsetMessage.keys)), getSelf());
                 })
                 .build();
     }

--- a/src/main/java/org/distributed/systems/chord/actors/StorageActor.java
+++ b/src/main/java/org/distributed/systems/chord/actors/StorageActor.java
@@ -59,6 +59,8 @@ class StorageActor extends AbstractActor {
                     Future<Object> getSubsetFuture = Patterns.ask(storageActorGetReply.storageActor, new KeyValue.GetSubset(keyTransferMessage.keys), timeoutTransfer);
                     KeyValue.GetSubsetReply getSubsetReply = (KeyValue.GetSubsetReply) Await.result(getSubsetFuture, timeoutTransfer.duration());
                     this.storageService.putAll(getSubsetReply.keyValues);
+
+                    // todo call delete for keys (that contained a value)
                 })
                 .match(KeyValue.GetSubset.class, getSubsetMessage ->{
                     // Get subset from Key value store based on list of keys

--- a/src/main/java/org/distributed/systems/chord/messaging/GetActorRef.java
+++ b/src/main/java/org/distributed/systems/chord/messaging/GetActorRef.java
@@ -1,0 +1,21 @@
+package org.distributed.systems.chord.messaging;
+
+import akka.actor.ActorRef;
+
+public class GetActorRef {
+
+    public static class Request implements Command {
+
+        public Request() {
+
+        }
+    }
+
+    public static class Reply implements Command {
+        public ActorRef storageActor;
+
+        public Reply(ActorRef storageActor) {
+            this.storageActor = storageActor;
+        }
+    }
+}

--- a/src/main/java/org/distributed/systems/chord/messaging/KeyTransfer.java
+++ b/src/main/java/org/distributed/systems/chord/messaging/KeyTransfer.java
@@ -1,0 +1,18 @@
+package org.distributed.systems.chord.messaging;
+
+import akka.actor.ActorRef;
+
+import java.util.List;
+
+public class KeyTransfer {
+
+    public static class Request implements Command {
+        public final ActorRef successor;
+        public final List<Long> keys;
+
+        public Request(ActorRef successor, List<Long> keys) {
+            this.successor = successor;
+            this.keys = keys;
+        }
+    }
+}

--- a/src/main/java/org/distributed/systems/chord/messaging/KeyValue.java
+++ b/src/main/java/org/distributed/systems/chord/messaging/KeyValue.java
@@ -63,6 +63,22 @@ public class KeyValue {
             this.keyValues = keyValues;
         }
     }
+
+    public static class DeleteSubset implements Response{
+        public final List<Long> keys;
+
+        public DeleteSubset(List<Long> keys) {
+            this.keys = keys;
+        }
+    }
+
+    public static class DeleteSubsetReply implements Response{
+
+        public DeleteSubsetReply() {
+
+        }
+    }
+
     //TODO: delete original key
     public static class Delete implements  Command {
         public final String originalKey;

--- a/src/main/java/org/distributed/systems/chord/messaging/KeyValue.java
+++ b/src/main/java/org/distributed/systems/chord/messaging/KeyValue.java
@@ -1,54 +1,66 @@
 package org.distributed.systems.chord.messaging;
 
+import org.distributed.systems.chord.models.Pair;
+
 import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
 
 public class KeyValue {
 
     public static class Put implements Command {
-        public final String originalKey;
         public final long hashKey;
-        public final Serializable value;
+        public final Pair<String, Serializable> value;
 
 
-        public Put(String originalKey, long hashKey, Serializable value) {
-            this.originalKey = originalKey;
+        public Put(long hashKey, Pair<String, Serializable> value) {
             this.value = value;
             this.hashKey = hashKey;
         }
     }
 
     public static class PutReply implements Response {
-        private final String originalKey;
         public final long hashKey;
-        private final Serializable value;
+        public final Pair<String, Serializable> value;
 
-        public PutReply(String originalKey, long hashKey, Serializable value) {
-            this.originalKey = originalKey;
+        public PutReply(long hashKey, Pair<String, Serializable> value) {
             this.hashKey = hashKey;
             this.value = value;
         }
     }
 
     public static class Get implements Command {
-        public final String originalKey;
         public final long hashKey;
 
-        public Get(String originalKey, long hashKey) {
-            this.originalKey = originalKey;
+        public Get(long hashKey) {
             this.hashKey = hashKey;
         }
     }
 
     public static class GetReply implements Response {
 
-        public final String originalKey;
         public final long hashKey;
-        public final Serializable value;
+        public final Pair<String, Serializable> value;
 
-        public GetReply(String originalKey, long hashKey, Serializable value) {
-            this.originalKey = originalKey;
+        public GetReply(long hashKey, Pair<String, Serializable> value) {
             this.hashKey = hashKey;
             this.value = value;
+        }
+    }
+
+    public static class GetSubset implements Response{
+        public final List<Long> keys;
+
+        public GetSubset(List<Long> keys) {
+            this.keys = keys;
+        }
+    }
+
+    public static class GetSubsetReply implements Response{
+        public final Map<Long, Pair<String, Serializable>> keyValues;
+
+        public GetSubsetReply(Map<Long, Pair<String, Serializable>> keyValues) {
+            this.keyValues = keyValues;
         }
     }
 }

--- a/src/main/java/org/distributed/systems/chord/models/Pair.java
+++ b/src/main/java/org/distributed/systems/chord/models/Pair.java
@@ -1,6 +1,8 @@
 package org.distributed.systems.chord.models;
 
-public class Pair<L,R> {
+import java.io.Serializable;
+
+public class Pair<L, R> implements Serializable {
 
     private final L originalKey;
     private final R value;
@@ -10,11 +12,18 @@ public class Pair<L,R> {
         this.value = value;
     }
 
-    public L getOriginalKey() { return originalKey; }
-    public R getValue() { return value; }
+    public L getOriginalKey() {
+        return originalKey;
+    }
+
+    public R getValue() {
+        return value;
+    }
 
     @Override
-    public int hashCode() { return originalKey.hashCode() ^ value.hashCode(); }
+    public int hashCode() {
+        return originalKey.hashCode() ^ value.hashCode();
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/org/distributed/systems/chord/models/Pair.java
+++ b/src/main/java/org/distributed/systems/chord/models/Pair.java
@@ -1,0 +1,27 @@
+package org.distributed.systems.chord.models;
+
+public class Pair<L,R> {
+
+    private final L originalKey;
+    private final R value;
+
+    public Pair(L originalKey, R value) {
+        this.originalKey = originalKey;
+        this.value = value;
+    }
+
+    public L getOriginalKey() { return originalKey; }
+    public R getValue() { return value; }
+
+    @Override
+    public int hashCode() { return originalKey.hashCode() ^ value.hashCode(); }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Pair)) return false;
+        Pair pairo = (Pair) o;
+        return this.originalKey.equals(pairo.getOriginalKey()) &&
+                this.value.equals(pairo.getValue());
+    }
+
+}

--- a/src/main/java/org/distributed/systems/chord/service/StorageService.java
+++ b/src/main/java/org/distributed/systems/chord/service/StorageService.java
@@ -25,19 +25,20 @@ public class StorageService {
         return this.valueStore.get(key);
     }
 
-    public void putAll(Map<Long, Pair<String, Serializable>> valueStore){
+    public void putAll(Map<Long, Pair<String, Serializable>> valueStore) {
         this.valueStore.putAll(valueStore);
     }
-    public  Map<Long, Pair<String, Serializable>> getSubset(List<Long> keys){
+
+    public Map<Long, Pair<String, Serializable>> getSubset(List<Long> keys) {
         return keys.stream()
                 .filter(this.valueStore::containsKey)
                 .collect(Collectors.toMap(Function.identity(), this.valueStore::get));
     }
 
-    public void deleteSubset(List<Long> keys){
+    public void deleteSubset(List<Long> keys) {
         keys.stream()
                 .filter(this.valueStore::containsKey)
-                .collect(Collectors.toMap(Function.identity(), this.valueStore::remove));
+                .map(this.valueStore::remove);
     }
 
     public void delete(Long key) {

--- a/src/main/java/org/distributed/systems/chord/service/StorageService.java
+++ b/src/main/java/org/distributed/systems/chord/service/StorageService.java
@@ -28,14 +28,13 @@ public class StorageService {
     public void putAll(Map<Long, Pair<String, Serializable>> valueStore){
         this.valueStore.putAll(valueStore);
     }
-            //HashMap<Long, Pair<String, Serializable>>
     public  Map<Long, Pair<String, Serializable>> getSubset(List<Long> keys){
         return keys.stream()
                 .filter(this.valueStore::containsKey)
                 .collect(Collectors.toMap(Function.identity(), this.valueStore::get));
     }
 
-    public void delete(String originalKey) {
-        this.valueStore.remove(originalKey);
+    public void delete(Long key) {
+        this.valueStore.remove(key);
     }
 }

--- a/src/main/java/org/distributed/systems/chord/service/StorageService.java
+++ b/src/main/java/org/distributed/systems/chord/service/StorageService.java
@@ -1,23 +1,38 @@
 package org.distributed.systems.chord.service;
 
+import org.distributed.systems.chord.models.Pair;
+
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class StorageService {
 
-    private Map<String, Serializable> valueStore;
+    private Map<Long, Pair<String, Serializable>> valueStore;
 
     public StorageService() {
         this.valueStore = new HashMap<>();
     }
 
-    public void put(String key, Serializable value) {
+    public void put(long key, Pair<String, Serializable> value) {
         this.valueStore.put(key, value);
     }
 
-    public Serializable get(String key) {
+    public Pair<String, Serializable> get(long key) {
         return this.valueStore.get(key);
+    }
+
+    public void putAll(Map<Long, Pair<String, Serializable>> valueStore){
+        this.valueStore.putAll(valueStore);
+    }
+            //HashMap<Long, Pair<String, Serializable>>
+    public  Map<Long, Pair<String, Serializable>> getSubset(List<Long> keys){
+        return keys.stream()
+                .filter(this.valueStore::containsKey)
+                .collect(Collectors.toMap(Function.identity(), this.valueStore::get));
     }
 
 }

--- a/src/main/java/org/distributed/systems/chord/service/StorageService.java
+++ b/src/main/java/org/distributed/systems/chord/service/StorageService.java
@@ -34,6 +34,12 @@ public class StorageService {
                 .collect(Collectors.toMap(Function.identity(), this.valueStore::get));
     }
 
+    public void deleteSubset(List<Long> keys){
+        keys.stream()
+                .filter(this.valueStore::containsKey)
+                .collect(Collectors.toMap(Function.identity(), this.valueStore::remove));
+    }
+
     public void delete(Long key) {
         this.valueStore.remove(key);
     }


### PR DESCRIPTION
Added transfer of key responsibility when a node joins the network.
Changes:

- Changed the key value store from <String original key, Serializable value> to <Long hash key, Pair<String original key, Serializable value> value>
- Added a TransferRequest message (tell) from NodeActor to its Storage Actor
- Added a GetActorRef message (ask) from StorageActor to NodeActor
- Added a KeyValue.GetSubset message (ask) from StorageActor to StorageActor
- Added 2 methods in StorageService (putAll and getSubset)
- Only gets called by the joining node when its predecessor is about to be set in the Notify action